### PR TITLE
Add demo credentials to products page

### DIFF
--- a/src/products.html
+++ b/src/products.html
@@ -125,6 +125,7 @@
 							<a href="https://github.com/directus/app/releases" class="blue internal" target="_blank">Download the App</a>
 							<a href="https://docs.directus.io/app/user-guide.html" class="blue internal" target="_blank">User Guide</a>
 							<a href="https://directus.app" class="blue internal" target="_blank">Try the Demo</a>
+							<p>Demo Login: <span class="creds"> <code>admin@example.com</code> + <code>password</code></span></p>
 						</div>
 					</div>
 				</aside>


### PR DESCRIPTION
Users currently have to go back to index.html if they want to view the demo credentials. It would be benefitial if users could see the credentials before launching the Demo from products.html