### PR TITLE
catch internal links and use router

### DIFF
--- a/components/Base/Heading.vue
+++ b/components/Base/Heading.vue
@@ -40,7 +40,7 @@ const iconSize = computed(() => {
 			<BaseIcon v-if="icon && size !== 'title'" :name="icon" :size="iconSize" :weight="700" />
 
 			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span class="content" v-html="content" />
+			<span v-links class="content" v-html="content" />
 		</component>
 	</div>
 </template>

--- a/components/Base/Quote.vue
+++ b/components/Base/Quote.vue
@@ -12,7 +12,7 @@ defineProps<BaseQuoteProps>();
 <template>
 	<div class="base-quote">
 		<!-- eslint-disable-next-line vue/no-v-html -->
-		<blockquote class="quote" v-html="quote" />
+		<blockquote v-links class="quote" v-html="quote" />
 
 		<BaseByline :name="personName" :title="personTitle" :image="personImage" />
 	</div>

--- a/components/Base/Text.vue
+++ b/components/Base/Text.vue
@@ -20,42 +20,13 @@ withDefaults(defineProps<BaseTextProps>(), {
 	align: 'start',
 	size: 'medium',
 });
-
-const config = useRuntimeConfig();
-const contentEl = ref<HTMLElement | null>(null);
-
-onMounted(() => {
-	if (!contentEl.value) return;
-
-	// Intercept all the local links
-	const anchors = contentEl.value.getElementsByTagName('a');
-	if (!anchors) return;
-
-	Array.from(anchors).forEach((anchor) => {
-		const url = anchor.getAttribute('href');
-		if (!url) return;
-
-		// Add target blank to external links
-		if (!url.startsWith(config.public.site.url) && !url.startsWith('/')) {
-			anchor.setAttribute('target', '_blank');
-			anchor.setAttribute('rel', 'noopener noreferrer');
-			return;
-		} else {
-			// Add on click event to local links
-			anchor.addEventListener('click', (e) => {
-				e.preventDefault();
-				navigateTo(url);
-			});
-		}
-	});
-});
 </script>
 
 <template>
 	<div class="base-text-container">
 		<!-- eslint-disable vue/no-v-html -->
 		<div
-			ref="contentEl"
+			v-links
 			class="base-text"
 			:class="[`align-${align}`, `size-${size}`, `type-${type}`, `color-${color}`]"
 			v-html="content"

--- a/components/Base/Text.vue
+++ b/components/Base/Text.vue
@@ -20,12 +20,42 @@ withDefaults(defineProps<BaseTextProps>(), {
 	align: 'start',
 	size: 'medium',
 });
+
+const config = useRuntimeConfig();
+const contentEl = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+	if (!contentEl.value) return;
+
+	// Intercept all the local links
+	const anchors = contentEl.value.getElementsByTagName('a');
+	if (!anchors) return;
+
+	Array.from(anchors).forEach((anchor) => {
+		const url = anchor.getAttribute('href');
+		if (!url) return;
+
+		// Add target blank to external links
+		if (!url.startsWith(config.public.site.url) && !url.startsWith('/')) {
+			anchor.setAttribute('target', '_blank');
+			anchor.setAttribute('rel', 'noopener noreferrer');
+			return;
+		} else {
+			// Add on click event to local links
+			anchor.addEventListener('click', (e) => {
+				e.preventDefault();
+				navigateTo(url);
+			});
+		}
+	});
+});
 </script>
 
 <template>
 	<div class="base-text-container">
 		<!-- eslint-disable vue/no-v-html -->
 		<div
+			ref="contentEl"
 			class="base-text"
 			:class="[`align-${align}`, `size-${size}`, `type-${type}`, `color-${color}`]"
 			v-html="content"

--- a/components/Block/Code.vue
+++ b/components/Block/Code.vue
@@ -55,6 +55,7 @@ const activeSnippet = ref(0);
 				v-for="(snippet, index) in snippets"
 				v-show="activeSnippet === index"
 				:key="snippet.name"
+				v-links
 				class="snippet"
 				v-html="snippet.html"
 			/>

--- a/components/Nav/Banner.vue
+++ b/components/Nav/Banner.vue
@@ -32,7 +32,7 @@ const dismiss = (id: string) => {
 			<NuxtLink class="link" :href="banner.link ?? undefined">
 				<BaseIcon v-if="banner.icon" class="icon" :name="banner.icon" size="small" />
 				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span class="content" v-html="banner.content" />
+				<span v-links class="content" v-html="banner.content" />
 				<BaseIcon class="arrow" name="arrow_forward" size="small" />
 			</NuxtLink>
 

--- a/components/Nav/Footer.vue
+++ b/components/Nav/Footer.vue
@@ -58,7 +58,7 @@ const socials = {
 						</NuxtLink>
 
 						<!-- eslint-disable-next-line vue/no-v-html -->
-						<div v-if="globals" class="description" v-html="globals.description" />
+						<div v-if="globals" v-links class="description" v-html="globals.description" />
 					</li>
 
 					<li v-for="group of navPrimary.items" :key="group.id">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -61,6 +61,9 @@ export default defineNuxtConfig({
 			gtm: {
 				id: process.env.GOOGLE_TAG_MANAGER_ID!,
 			},
+			site: {
+				url: process.env.NUXT_PUBLIC_SITE_URL!,
+			},
 		},
 	},
 

--- a/plugins/links.ts
+++ b/plugins/links.ts
@@ -1,0 +1,33 @@
+export default defineNuxtPlugin((nuxtApp) => {
+	nuxtApp.vueApp.directive('links', {
+		mounted(el: HTMLElement) {
+			const anchors = Array.from(el.getElementsByTagName('a'));
+
+			for (const anchor of anchors) {
+				const href = anchor.getAttribute('href');
+
+				if (!href) return;
+
+				const url = new URL(href, window.location.origin);
+
+				const isLocal = url.hostname === 'directus.io';
+
+				if (isLocal) {
+					anchor.addEventListener('click', (e) => {
+						e.preventDefault();
+						const { pathname, searchParams, hash } = new URL(anchor.href);
+
+						navigateTo({
+							path: pathname,
+							hash: hash,
+							query: Object.fromEntries(searchParams.entries()),
+						});
+					});
+				} else {
+					anchor.setAttribute('target', '_blank');
+					anchor.setAttribute('rel', 'noopener noreferrer');
+				}
+			}
+		},
+	});
+});

--- a/plugins/links.ts
+++ b/plugins/links.ts
@@ -14,7 +14,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 
 				if (isLocal) {
 					anchor.addEventListener('click', (e) => {
-						e.preventDefault();
 						const { pathname, searchParams, hash } = new URL(anchor.href);
 
 						navigateTo({
@@ -22,6 +21,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 							hash: hash,
 							query: Object.fromEntries(searchParams.entries()),
 						});
+
+						e.preventDefault();
 					});
 				} else {
 					anchor.setAttribute('target', '_blank');


### PR DESCRIPTION
One issue for the WYSIWYG editor is internal links from resources / blogs etc - right now it would cause a full page reload. This should fix that and also open external links in a new tab.

Notes:
- Was debating whether this should be on BaseText or BlockRichText in order to keep our base components pure but we're using the WYSIWYG in a few other places like headings and on the Team collection