### PR TITLE
Only allow published dev blog posts to appear in RSS feed

### DIFF
--- a/server/routes/rss.xml.ts
+++ b/server/routes/rss.xml.ts
@@ -71,6 +71,9 @@ export default defineEventHandler(async (event) => {
 			],
 			limit: 20,
 			sort: ['-date_published'],
+			filter: {
+				status: { _eq: 'published' },
+			},
 		})
 	);
 


### PR DESCRIPTION
The dev blog has a concept of 'hidden' posts, but they were still being published to the RSS feed. This PR fixes that. 