### PR TITLE
Enhance SDK request queue

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,7 +37,7 @@ const fetchPagePermalinks = async () => {
 						},
 					},
 				],
-			} as any, // @TODO fix as any when SDK is updated
+			},
 			fields: ['slug'],
 			limit: -1,
 		})

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
 	"dependencies": {
 		"@nuxt/image": "1.0.0-rc.3",
 		"floating-vue": "2.0.0-beta.24",
-		"p-queue": "7.3.4"
+		"p-queue": "7.4.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 2.0.0-beta.24
     version: 2.0.0-beta.24(vue@3.3.4)
   p-queue:
-    specifier: 7.3.4
-    version: 7.3.4
+    specifier: 7.4.1
+    version: 7.4.1
 
 devDependencies:
   '@directus/sdk':
@@ -4442,8 +4442,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  /eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: false
 
   /events@3.3.0:
@@ -7011,11 +7011,11 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
-  /p-queue@7.3.4:
-    resolution: {integrity: sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==}
+  /p-queue@7.4.1:
+    resolution: {integrity: sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==}
     engines: {node: '>=12'}
     dependencies:
-      eventemitter3: 4.0.7
+      eventemitter3: 5.0.1
       p-timeout: 5.1.0
     dev: false
 


### PR DESCRIPTION
The recent builds are failing because of the SDK requests hitting the rate limit.

We should use `intervalCap` instead of `concurrency`, like we're doing in the Data Studio (https://github.com/directus/directus/blob/45847a61a2d22a8191d60174e387e1db693f4ee4/app/src/stores/server.ts#L107).

Also this wraps the queue around `fetch` to get accurate resolving times and retries if 429 occurs.

---

The build is probably slower now... But at least succeeds again 😅 

It's not clear to me why the problems have suddenly become more frequent. Also the server limit is 25 requests per 1s AFAICS but almost every request fails when configuring the queue like that 🤔  