### PR TITLE
Various improvements for Directus TV

### DIFF
--- a/components/Tv/TVCategory.vue
+++ b/components/Tv/TVCategory.vue
@@ -3,7 +3,12 @@
 		<h2>{{ title }}</h2>
 		<ul>
 			<li v-for="show in shows" :key="show.shows_id.id">
-				<TVShow :slug="show.shows_id.slug" :tile="show.shows_id.tile" :title="show.shows_id.title" />
+				<TVShow
+					:slug="show.shows_id.slug"
+					:tile="show.shows_id.tile"
+					:title="show.shows_id.title"
+					:description="show.shows_id.one_liner"
+				/>
 			</li>
 		</ul>
 	</div>

--- a/components/Tv/TVEpisode.vue
+++ b/components/Tv/TVEpisode.vue
@@ -1,6 +1,6 @@
 <template>
 	<NuxtLink :to="`/tv/${show.slug}/${episode.slug}`" class="episode">
-		<img :src="`${directusUrl}/assets/${episode.tile}?width=300`" alt="" />
+		<img :src="`${directusUrl}/assets/${episode.tile}?width=600`" alt="" />
 		<div>
 			<h3>
 				{{ episode.episode_number }}:

--- a/components/Tv/TVHero.vue
+++ b/components/Tv/TVHero.vue
@@ -6,7 +6,7 @@
 		<TVNavigation />
 		<BaseContainer>
 			<div class="featured">
-				<img :src="`${directusUrl}/assets/${logo}?width=300`" :alt="title" />
+				<img :src="`${directusUrl}/assets/${logo}?width=600`" :alt="title" />
 				<h2>{{ title }}</h2>
 				<p>{{ description }}</p>
 

--- a/components/Tv/TVHero.vue
+++ b/components/Tv/TVHero.vue
@@ -78,7 +78,7 @@ defineProps({
 		color: white;
 		outline: 2px solid white;
 		&:hover {
-			color: inherit;
+			color: white !important;
 			--background-color: rgba(255, 255, 255, 0.25);
 		}
 	}

--- a/components/Tv/TVShow.vue
+++ b/components/Tv/TVShow.vue
@@ -1,6 +1,6 @@
 <template>
 	<NuxtLink :to="`/tv/${slug}`" class="show">
-		<img :src="`${directusUrl}/assets/${tile}?width=300`" :alt="title" />
+		<img :src="`${directusUrl}/assets/${tile}?width=600`" :alt="title" />
 		<h3>{{ title }}</h3>
 		<p>{{ description }}</p>
 	</NuxtLink>

--- a/components/Tv/TVShow.vue
+++ b/components/Tv/TVShow.vue
@@ -2,6 +2,7 @@
 	<NuxtLink :to="`/tv/${slug}`" class="show">
 		<img :src="`${directusUrl}/assets/${tile}?width=300`" :alt="title" />
 		<h3>{{ title }}</h3>
+		<p>{{ description }}</p>
 	</NuxtLink>
 </template>
 
@@ -16,6 +17,7 @@ defineProps({
 	slug: String,
 	tile: String,
 	title: String,
+	description: String,
 });
 </script>
 
@@ -30,8 +32,15 @@ defineProps({
 	}
 	h3 {
 		color: white;
+		font-size: 1rem;
+		margin-top: 0.75rem;
+	}
+	p {
+		color: #9da6b3;
+		opacity: 0.8;
 		font-size: 0.8rem;
 		margin-top: 0.5rem;
+		line-height: var(--line-height-sm);
 	}
 }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -75,6 +75,7 @@ export default defineNuxtConfig({
 		public: {
 			directusUrl: process.env.DIRECTUS_URL,
 			tvUrl: process.env.DIRECTUS_TV_URL,
+			baseUrl: process.env.NUXT_PUBLIC_SITE_URL,
 			gtm: {
 				id: process.env.GOOGLE_TAG_MANAGER_ID!,
 			},

--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -23,7 +23,7 @@
 				<div class="links">
 					<NuxtLink :to="`/tv/${route.params.show}`" class="show">
 						<img
-							:src="`${directusUrl}/assets/${episode.season.show.tile}?width=300`"
+							:src="`${directusUrl}/assets/${episode.season.show.tile}?width=600`"
 							:alt="episode.season.show.title"
 						/>
 					</NuxtLink>

--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -74,7 +74,7 @@
 import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const {
-	public: { tvUrl },
+	public: { tvUrl, baseUrl },
 } = useRuntimeConfig();
 
 const route = useRoute();
@@ -156,6 +156,7 @@ useSeoMeta({
 	ogDescription: episode.description,
 	ogImage: `${directusUrl}/assets/${episode.tile}`,
 	twitterCard: 'summary_large_image',
+	ogUrl: `${baseUrl}/tv/${route.params.show}/${route.params.episode}`,
 });
 </script>
 

--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -137,8 +137,8 @@ const [next] = await directus.request(
 							],
 						},
 					],
-				}
-			]
+				},
+			],
 		},
 	}),
 );
@@ -195,6 +195,7 @@ iframe {
 		gap: 1em;
 		margin-top: 0.5rem;
 		a {
+			display: none;
 			color: inherit;
 			text-decoration: none;
 		}

--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -10,6 +10,27 @@
 			></iframe>
 		</div>
 		<BaseContainer>
+			<div class="nav">
+				<BaseButton
+					label="Back to Show"
+					class="secondary"
+					:href="`/tv/${route.params.show}`"
+					icon-start="arrow_back"
+					color="white"
+					size="small"
+					outline
+				/>
+				<BaseButton
+					v-if="next"
+					:label="isNextSeason ? 'Next Season' : 'Next Episode'"
+					class="secondary"
+					:href="`/tv/${route.params.show}/${next.slug}`"
+					icon="arrow_forward"
+					color="white"
+					size="small"
+					outline
+				/>
+			</div>
 			<div class="meta">
 				<div class="details">
 					<h1>{{ episode.title }}</h1>
@@ -68,6 +89,62 @@ const [episode] = await directus.request(
 	}),
 );
 
+const [next] = await directus.request(
+	readItems('episodes', {
+		fields: ['*'],
+		filter: {
+			_and: [
+				// Same show
+				{
+					season: {
+						show: {
+							slug: {
+								_eq: route.params.show,
+							},
+						},
+					},
+				},
+				{
+					_or: [
+						// Is the next episode in this season
+						{
+							_and: [
+								{
+									season: {
+										number: {
+											_eq: episode.season.number,
+										},
+									},
+								},
+								{
+									episode_number: { _eq: episode.episode_number + 1 },
+								},
+							],
+						},
+						// Is the first episode of the next season
+						{
+							_and: [
+								{
+									season: {
+										number: {
+											_eq: episode.season.number + 1,
+										},
+									},
+								},
+								{
+									episode_number: { _eq: 1 },
+								},
+							],
+						},
+					],
+				}
+			]
+		},
+	}),
+);
+
+const isNextSeason = next?.episode_number == 1;
+
 definePageMeta({
 	layout: 'tv',
 });
@@ -89,10 +166,25 @@ iframe {
 	background: black;
 }
 
+.nav {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 2rem;
+	a {
+		--background-color: rgba(255, 255, 255, 0.12);
+		color: white;
+		outline: 2px solid white;
+		&:hover {
+			color: white !important;
+			--background-color: rgba(255, 255, 255, 0.25);
+		}
+	}
+}
+
 .meta {
 	display: grid;
 	gap: 1rem;
-	margin: 4rem 0;
+	margin: 3rem 0;
 	h1 {
 		margin-top: 0;
 		line-height: 1;

--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -150,8 +150,8 @@ definePageMeta({
 });
 
 useSeoMeta({
-	title: episode.title,
-	ogTitle: episode.title,
+	title: `${episode.title} | Directus TV`,
+	ogTitle: `${episode.title} | Directus TV`,
 	description: episode.description,
 	ogDescription: episode.description,
 	ogImage: `${directusUrl}/assets/${episode.tile}`,

--- a/pages/tv/[show]/index.vue
+++ b/pages/tv/[show]/index.vue
@@ -82,8 +82,8 @@ definePageMeta({
 });
 
 useSeoMeta({
-	title: show.title,
-	ogTitle: show.title,
+	title: `${show.title} | Directus TV`,
+	ogTitle: `${show.title} | Directus TV`,
 	description: show.description,
 	ogDescription: show.description,
 	ogImage: `${directusUrl}/assets/${show.tile}`,

--- a/pages/tv/[show]/index.vue
+++ b/pages/tv/[show]/index.vue
@@ -31,7 +31,7 @@ const route = useRoute();
 import { createDirectus, rest, readItems } from '@directus/sdk';
 
 const {
-	public: { tvUrl },
+	public: { tvUrl, baseUrl },
 } = useRuntimeConfig();
 
 const directusUrl = process.env.DIRECTUS_TV_URL || tvUrl;
@@ -88,6 +88,7 @@ useSeoMeta({
 	ogDescription: show.description,
 	ogImage: `${directusUrl}/assets/${show.tile}`,
 	twitterCard: 'summary_large_image',
+	ogUrl: `${baseUrl}/tv/${route.params.show}`,
 });
 </script>
 

--- a/pages/tv/index.vue
+++ b/pages/tv/index.vue
@@ -17,7 +17,7 @@
 import { createDirectus, rest, readItems, readSingleton } from '@directus/sdk';
 
 const {
-	public: { tvUrl },
+	public: { tvUrl, baseUrl },
 } = useRuntimeConfig();
 
 const directusUrl = process.env.DIRECTUS_TV_URL || tvUrl;
@@ -62,6 +62,7 @@ useSeoMeta({
 	ogDescription: seoDesc,
 	ogImage: `${directusUrl}/assets/${globals.og}`,
 	twitterCard: 'summary_large_image',
+	ogUrl: `${baseUrl}/tv`,
 });
 </script>
 


### PR DESCRIPTION
This PR includes many small changes that have become needed in the two weeks since launch. 

- Fixes #106 by including `ogUrl` in TV pages' `useSeoMeta()`. @bryantgillespie will need to implement this for other pages. 
- Fixes #107 by showing a Back to Show button and a Next Episode/Next Season button (if existent).
![2024-01-05T1306 32](https://github.com/directus/website/assets/1461554/9747a02b-2ab5-434a-972d-203e9b2fd582)
- Fixes #108 by increasing the size of requested assets for show/episode tiles. 
- Fixes #110 by overriding default button hover styling for secondary buttons in the `TVHero` component.
- Fixes #111 by adding show descriptions to the CMS and then rendering them on the homepage.
![2024-01-05T1308 31](https://github.com/directus/website/assets/1461554/d6a04b44-6f8f-45f4-91ae-e498aeb2d854)
- Fixes #112 by removing duplicate meta information on episode pages. 
- Fixes #114 by adding `| Directus TV` to show and episode titles.
