### PR TITLE
Add Typeform Embeds

### DIFF
--- a/components/Base/TypeForm.vue
+++ b/components/Base/TypeForm.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+export interface BaseHsFormProps {
+	formId: string;
+	labels?: boolean;
+	inline?: boolean;
+	align?: 'left' | 'center';
+	routeToMeetingLinkOnSuccess?: boolean;
+}
+
+const props = withDefaults(defineProps<BaseHsFormProps>(), {
+	labels: true,
+	inline: false,
+	align: 'center',
+});
+
+const { formId } = toRefs(props);
+
+const { $directus, $readSingleton } = useNuxtApp();
+
+const renderTypeForm = () => {
+	// @ts-ignore -- Typeform is not typed
+	window.tf?.createWidget(unref(formId), {});
+};
+
+useHead({
+	script: [
+		{
+			src: 'https://embed.typeform.com/next/embed.js',
+			// defer: true,
+			onload: renderTypeForm,
+		},
+	],
+});
+
+const generatedId = computed(() => `typeform-${unref(formId)}`);
+
+const { theme } = useTheme();
+
+onMounted(renderTypeForm);
+
+watch(formId, renderTypeForm);
+</script>
+
+<template>
+	<div>
+		<div :id="generatedId" :data-tf-widget="formId" :data-tf-height="550" />
+	</div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/components/Block/Form.vue
+++ b/components/Block/Form.vue
@@ -8,7 +8,12 @@ const props = defineProps<BlockProps>();
 const { data: block } = useAsyncData(props.uuid, () =>
 	$directus.request(
 		$readItem('block_form', props.uuid, {
-			fields: ['alignment', 'show_labels', 'inline', { form: ['hubspot_form_id', 'route_to_meeting_link_on_success'] }],
+			fields: [
+				'alignment',
+				'show_labels',
+				'inline',
+				{ form: ['hubspot_form_id', 'typeform_form_id', 'route_to_meeting_link_on_success'] },
+			],
 		}),
 	),
 );
@@ -22,5 +27,12 @@ const { data: block } = useAsyncData(props.uuid, () =>
 		:inline="block.inline"
 		:align="block.alignment ?? undefined"
 		:route-to-meeting-link-on-success="block.form.route_to_meeting_link_on_success ?? undefined"
+	/>
+	<BaseTypeForm
+		v-if="block && block.form.typeform_form_id"
+		:form-id="block.form.typeform_form_id"
+		:labels="block.show_labels"
+		:inline="block.inline"
+		:align="block.alignment ?? undefined"
 	/>
 </template>

--- a/types/schema/content/form.ts
+++ b/types/schema/content/form.ts
@@ -10,5 +10,6 @@ export interface Form {
 	type: string | null;
 	title: string | null;
 	hubspot_form_id: string | null;
+	typeform_form_id: string | null;
 	route_to_meeting_link_on_success: boolean | null;
 }


### PR DESCRIPTION
Adds the ability to use Typeforms as embedded forms in addition to HubSpot.