### PR TITLE
Reverting latest image changes

### DIFF
--- a/components/Base/DirectusImage.vue
+++ b/components/Base/DirectusImage.vue
@@ -18,5 +18,5 @@ defineProps<DirectusImageProps>();
 </script>
 
 <template>
-	<NuxtImg :src="uuid" :alt="alt" :width="width" :height="height" format="auto" loading="lazy" densities="x2" />
+	<NuxtImg :src="uuid" :alt="alt" :width="width" :height="height" format="auto" loading="lazy" />
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,7 +72,6 @@ export default defineNuxtConfig({
 	// Nuxt Image Configuration - https://image.nuxt.com/get-started/installation
 	image: {
 		provider: 'directus',
-		quality: 95,
 		directus: {
 			baseURL: `${process.env.DIRECTUS_URL}/assets/`,
 		},


### PR DESCRIPTION
The image transforms are causing the Directus instance to bog down and as such it's killing images on the live site which is far worse than them being blurry..