### PR TITLE
Add more interval

### DIFF
--- a/plugins/directus.ts
+++ b/plugins/directus.ts
@@ -5,7 +5,7 @@ import type { Schema } from '~/types/schema';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const queue = new Queue({ intervalCap: 15, interval: 500, carryoverConcurrencyCount: true });
+const queue = new Queue({ intervalCap: 15, interval: 1000, carryoverConcurrencyCount: true });
 
 export default defineNuxtPlugin((nuxtApp) => {
 	const route = useRoute();

--- a/plugins/directus.ts
+++ b/plugins/directus.ts
@@ -5,7 +5,7 @@ import type { Schema } from '~/types/schema';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const queue = new Queue({ intervalCap: 15, interval: 1000, carryoverConcurrencyCount: true });
+const queue = new Queue({ intervalCap: 10, interval: 1000, carryoverConcurrencyCount: true });
 
 export default defineNuxtPlugin((nuxtApp) => {
 	const route = useRoute();

--- a/plugins/tv.ts
+++ b/plugins/tv.ts
@@ -5,7 +5,7 @@ import type { Schema } from '~/types/schema';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const queue = new Queue({ intervalCap: 15, interval: 500, carryoverConcurrencyCount: true });
+const queue = new Queue({ intervalCap: 15, interval: 1000, carryoverConcurrencyCount: true });
 
 export default defineNuxtPlugin((nuxtApp) => {
 	const route = useRoute();

--- a/plugins/tv.ts
+++ b/plugins/tv.ts
@@ -5,7 +5,7 @@ import type { Schema } from '~/types/schema';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const queue = new Queue({ intervalCap: 15, interval: 1000, carryoverConcurrencyCount: true });
+const queue = new Queue({ intervalCap: 10, interval: 1000, carryoverConcurrencyCount: true });
 
 export default defineNuxtPlugin((nuxtApp) => {
 	const route = useRoute();


### PR DESCRIPTION
We've been having some weird pressure limiter issues during build that break a page silently. 
So updating the p-queue instance to dial back the interval and concurrency.