### PR TITLE
Limit scope of margin rule

### DIFF
--- a/components/ResourcePage.vue
+++ b/components/ResourcePage.vue
@@ -379,10 +379,6 @@ const related = computed(() => {
 			border-block-end: 1px solid var(--gray-200);
 			margin-block-end: var(--space-10);
 
-			* + * {
-				margin-block-start: var(--space-10);
-			}
-
 			.featured {
 				width: 100%;
 			}
@@ -499,5 +495,9 @@ const related = computed(() => {
 			grid-template-columns: auto 1fr var(--space-64);
 		}
 	}
+}
+
+.content main > * + * {
+	margin-block-start: var(--space-10);
 }
 </style>


### PR DESCRIPTION
Before: * + * applied to all adjacent siblings globally, regardless of their parent container. This led to unintended spacing in components like buttons or bylines that might also have adjacent siblings.
![image](https://github.com/user-attachments/assets/497c0e90-ac04-4696-9cf2-91c463469a78)
![image](https://github.com/user-attachments/assets/8fb5e16f-b62d-4f21-9a52-ca9cb53e9504)


After: .content main > * + * limits the rule to direct sibling elements inside the main tag of .content only, ensuring it doesn't apply globally or affect nested elements within buttons or other components.
![image](https://github.com/user-attachments/assets/68fb9bc7-ed1f-4840-932d-94923aad54dc)
![image](https://github.com/user-attachments/assets/259107b0-54d0-402f-8978-499187d8a950)
