### PR TITLE
Add PostHog Proxy

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -98,6 +98,7 @@ export default defineNuxtConfig({
 	// Posthog configuration
 	posthog: {
 		capturePageViews: true,
+		host: process.env.CONTEXT ? (process.env.CONTEXT === 'production' ? `${process.env.URL}/ingest` : `${process.env.DEPLOY_PRIME_URL}/ingest`) : process.env.POSTHOG_API_HOST,
 	},
 
 	// Nuxt Image Configuration - https://image.nuxt.com/get-started/installation

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -98,7 +98,11 @@ export default defineNuxtConfig({
 	// Posthog configuration
 	posthog: {
 		capturePageViews: true,
-		host: process.env.CONTEXT ? (process.env.CONTEXT === 'production' ? `${process.env.URL}/ingest` : `${process.env.DEPLOY_PRIME_URL}/ingest`) : process.env.POSTHOG_API_HOST,
+		host: process.env.CONTEXT
+			? process.env.CONTEXT === 'production'
+				? `${process.env.URL}/ingest`
+				: `${process.env.DEPLOY_PRIME_URL}/ingest`
+			: process.env.POSTHOG_API_HOST,
 	},
 
 	// Nuxt Image Configuration - https://image.nuxt.com/get-started/installation

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -98,11 +98,15 @@ export default defineNuxtConfig({
 	// Posthog configuration
 	posthog: {
 		capturePageViews: true,
-		host: process.env.CONTEXT
-			? process.env.CONTEXT === 'production'
-				? `${process.env.URL}/ingest`
-				: `${process.env.DEPLOY_PRIME_URL}/ingest`
-			: process.env.POSTHOG_API_HOST,
+		host: (() => {
+			if (process.env.CONTEXT) {
+				return process.env.CONTEXT === 'production'
+					? `${process.env.URL}/ingest`
+					: `${process.env.DEPLOY_PRIME_URL}/ingest`;
+			}
+
+			return process.env.POSTHOG_API_HOST;
+		})(),
 	},
 
 	// Nuxt Image Configuration - https://image.nuxt.com/get-started/installation

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,3 @@
 /docs/* https://docs-six-phi-91.vercel.app/docs/:splat 200!
+/ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200
+/ingest/*  https://us.i.posthog.com/:splat  200


### PR DESCRIPTION
This pull request adds rewrite proxy rules to Netlify deployments and configures the base API Host for PostHog depending on the deployment context. So the main prod deployment uses the main domain, other branches/pr's use their branch url, and all other cases use the base posthog url.

- `nuxt.config.ts`: Added logic to set the `host` for Posthog based on the netlify deployment context.
- `public/_redirects`: Added new redirect rules for `/ingest/static/*` and `/ingest/*` paths to point to Posthog's asset and API hosts, respectively.