### PR TITLE
[TV] Check show slug on episode page

### DIFF
--- a/pages/tv/[show]/[episode].vue
+++ b/pages/tv/[show]/[episode].vue
@@ -48,7 +48,20 @@ const { data: episode } = await useAsyncData(
 						seo: ['title', 'meta_description'],
 					},
 				],
-				filter: { slug: { _eq: route.params.episode } },
+				filter: {
+					_and: [
+						{
+							slug: { _eq: route.params.episode },
+						},
+						{
+							season: {
+								show: {
+									slug: { _eq: route.params.show },
+								},
+							},
+						},
+					],
+				},
 			}),
 		);
 	},


### PR DESCRIPTION
This pull request includes a change to the `pages/tv/[show]/[episode].vue` file to enhance the filtering logic for fetching episode data. The most important change is the addition of a more complex filter that ensures the episode belongs to the correct show.

This fixes a known bug today rediscovered by @bb-loft