### PR TITLE
Fix spacing issues on top of page

### DIFF
--- a/components/Base/Block.vue
+++ b/components/Base/Block.vue
@@ -5,10 +5,12 @@ export interface BaseBlockProps {
 	type: BlockType;
 	uuid: string;
 	width?: 'full' | 'standard' | 'narrow';
+	isFirstBlock?: boolean;
 }
 
 withDefaults(defineProps<BaseBlockProps>(), {
 	width: 'standard',
+	isFirstBlock: false,
 });
 
 const components: Record<BlockType, ReturnType<typeof resolveComponent>> = {
@@ -50,7 +52,7 @@ const components: Record<BlockType, ReturnType<typeof resolveComponent>> = {
 </script>
 
 <template>
-	<div class="block-container" :class="width">
+	<div class="block-container" :class="[width, { 'first-block': isFirstBlock }]">
 		<component :is="components[type]" :uuid="uuid" />
 	</div>
 </template>
@@ -58,6 +60,12 @@ const components: Record<BlockType, ReturnType<typeof resolveComponent>> = {
 <style lang="scss" scoped>
 .block-container {
 	container-type: inline-size;
+
+	&.first-block {
+		:deep(> *) {
+			padding-block-start: 0;
+		}
+	}
 
 	&.narrow {
 		grid-column: narrow;

--- a/components/Base/Block.vue
+++ b/components/Base/Block.vue
@@ -62,9 +62,7 @@ const components: Record<BlockType, ReturnType<typeof resolveComponent>> = {
 	container-type: inline-size;
 
 	&.first-block {
-		:deep(> *) {
-			padding-block-start: 0;
-		}
+		padding-block-start: 0;
 	}
 
 	&.narrow {

--- a/components/Block/Header.vue
+++ b/components/Block/Header.vue
@@ -194,9 +194,4 @@ autoApply(`[data-block-id="${props.uuid}"]`, refresh);
 		margin-block-start: var(--space-3);
 	}
 }
-@media (max-width: 800px) {
-	.header {
-		padding-block-start: var(--nav-offset);
-	}
-}
 </style>

--- a/components/PageBuilder.vue
+++ b/components/PageBuilder.vue
@@ -2,7 +2,7 @@
 import type { BlockType, PageBlock, Experiment, ExperimentVariant } from '~/types/schema';
 
 interface PageBuilderProps {
-	spacingTop?: 'small' | 'normal';
+	spacingTop?: 'none' | 'x-small' | 'small' | 'normal';
 	sections: PageBuilderSection[];
 }
 
@@ -36,16 +36,22 @@ withDefaults(defineProps<PageBuilderProps>(), {
 		:background="section.background"
 		:offset-negative-margin="sections[i + 1]?.negativeTopMargin"
 		:negative-margin="section.negativeTopMargin"
-		:nav-offset="spacingTop"
+		:nav-offset="i === 0 ? spacingTop : 'none'"
 		:spacing="section.spacing"
+		:is-first-section="i === 0"
 	>
 		<BaseContainer
-			v-for="block in section.blocks"
+			v-for="(block, blockIndex) in section.blocks"
 			:id="block.key ?? undefined"
 			:key="block.id"
 			:spacing="block.spacing"
 		>
-			<BaseBlock :type="block.collection" :uuid="block.item" :width="block.width" />
+			<BaseBlock
+				:type="block.collection"
+				:uuid="block.item"
+				:width="block.width"
+				:isFirstBlock="i === 0 && blockIndex === 0"
+			/>
 		</BaseContainer>
 	</PageSection>
 </template>

--- a/components/PageSection.vue
+++ b/components/PageSection.vue
@@ -7,6 +7,7 @@ interface PageSectionProps {
 	negativeMargin?: boolean;
 	offsetNegativeMargin?: boolean;
 	spacing?: 'none' | 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
+	isFirstSection?: boolean;
 }
 
 withDefaults(defineProps<PageSectionProps>(), {
@@ -15,6 +16,7 @@ withDefaults(defineProps<PageSectionProps>(), {
 	offsetNegativeMargin: false,
 	navOffset: 'normal',
 	spacing: 'medium',
+	isFirstSection: false,
 });
 
 const { height: headerHeight } = useHeaderHeight();
@@ -29,7 +31,11 @@ const { height: headerHeight } = useHeaderHeight();
 			`bg-${background}`,
 			`space-${spacing}`,
 			`nav-offset-${navOffset}`,
-			{ offset: offsetNegativeMargin, negative: negativeMargin },
+			{
+				offset: offsetNegativeMargin,
+				negative: negativeMargin,
+				'first-section': isFirstSection,
+			},
 		]"
 	>
 		<ArtLines v-if="background === 'pristine-white-lines'" />
@@ -54,6 +60,12 @@ const { height: headerHeight } = useHeaderHeight();
 	@media (width > 68rem) {
 		--negative-offset: var(--space-64);
 		--negative: calc(-1 * var(--space-36));
+	}
+
+	&.first-section {
+		:deep(> .base-container:first-child) {
+			padding-block-start: 0;
+		}
 	}
 
 	&.offset {

--- a/components/PageSection.vue
+++ b/components/PageSection.vue
@@ -46,8 +46,7 @@ const { height: headerHeight } = useHeaderHeight();
 <style lang="scss" scoped>
 .page-section {
 	background-color: var(--background);
-	padding-block-end: var(--padding-base);
-	padding-block-start: var(--nav-offset);
+	padding-block: var(--padding-base);
 
 	--negative-offset: var(--space-32);
 	--negative: calc(-1 * var(--space-8));
@@ -63,9 +62,7 @@ const { height: headerHeight } = useHeaderHeight();
 	}
 
 	&.first-section {
-		:deep(> .base-container:first-child) {
-			padding-block-start: 0;
-		}
+		padding-block-start: var(--nav-offset);
 	}
 
 	&.offset {
@@ -148,7 +145,6 @@ const { height: headerHeight } = useHeaderHeight();
 
 	&.nav-offset-none {
 		--nav-offset: calc(v-bind(headerHeight) * 1px);
-		padding-block-start: 0;
 
 		@media (width > 68rem) {
 			--nav-offset: 0;

--- a/components/PageSection.vue
+++ b/components/PageSection.vue
@@ -40,7 +40,8 @@ const { height: headerHeight } = useHeaderHeight();
 <style lang="scss" scoped>
 .page-section {
 	background-color: var(--background);
-	padding-block: var(--padding-base);
+	padding-block-end: var(--padding-base);
+	padding-block-start: var(--nav-offset);
 
 	--negative-offset: var(--space-32);
 	--negative: calc(-1 * var(--space-8));
@@ -135,6 +136,7 @@ const { height: headerHeight } = useHeaderHeight();
 
 	&.nav-offset-none {
 		--nav-offset: calc(v-bind(headerHeight) * 1px);
+		padding-block-start: 0;
 
 		@media (width > 68rem) {
 			--nav-offset: 0;
@@ -180,11 +182,10 @@ const { height: headerHeight } = useHeaderHeight();
 	&:has(:last-child:is(.base-container > .base-divider)) {
 		padding-block-end: 0;
 	}
-}
 
-.header-container + .page-section {
-	/* Extra padding block start for the fixed NavHeader on mobile */
-	padding-block-start: var(--nav-offset);
+	.header-container + .page-section {
+		padding-block-start: var(--nav-offset);
+	}
 }
 
 .bg-simple-gray {


### PR DESCRIPTION
Fix spacing issues with top of pages:
- Block spacing no longer impacts the top of the pages spacing for the first block
- Block spacing description updated to reflect actual useage
- Page Top spacing updated to allow additional options and be only source of spacing on the top of the page

### Examples:
**Before:**
![image](https://github.com/user-attachments/assets/2c68b7c7-d03e-4b7a-bc73-ad0db18c2685)

**After:**
![image](https://github.com/user-attachments/assets/0180f638-2df3-4360-b171-f1ecaf80588a)

**Before**
![image](https://github.com/user-attachments/assets/7ce9df8a-c15a-418a-99b7-b697648c2ac9)

**After**
![image](https://github.com/user-attachments/assets/93490188-f4f3-45ed-ab5e-3d477af1d3bd)


