### PR TITLE
Add Events to Marketplace Interactions

### DIFF
--- a/components/Block/SearchDirectory.vue
+++ b/components/Block/SearchDirectory.vue
@@ -102,6 +102,13 @@ const hitsPerPage = computed(() => block.value?.hits_per_page || config.value.se
 					:extension="item"
 					:to="`/extensions/${item.name}`"
 					:current-sort="currentSort"
+					v-capture="{
+						name: 'marketing.website.marketplace.extension.card.click',
+						properties: {
+							extension_id: item.objectID || item.id,
+							extension_name: item.name,
+						},
+					}"
 				/>
 			</BaseCardGroup>
 
@@ -116,6 +123,14 @@ const hitsPerPage = computed(() => block.value?.hits_per_page || config.value.se
 					:to="`/integrations/${item.slug}`"
 					:badge="item.category ?? undefined"
 					media-style="image-fill-16-9"
+					v-capture="{
+						name: 'marketing.website.marketplace.integration.card.click',
+						properties: {
+							integration_id: item.objectID || item.id,
+							integration_name: item.name,
+							integration_slug: item.slug,
+						},
+					}"
 				/>
 			</div>
 
@@ -130,6 +145,14 @@ const hitsPerPage = computed(() => block.value?.hits_per_page || config.value.se
 					:to="`/templates/${item.slug}`"
 					:badge="item.framework || item.use_cases?.[0] || 'Template'"
 					media-style="image-fill-16-9"
+					v-capture="{
+						name: 'marketing.website.marketplace.template.card.click',
+						properties: {
+							template_id: item.id,
+							template_name: item.name,
+							template_slug: item.slug,
+						},
+					}"
 				/>
 			</div>
 		</template>

--- a/layers/marketplace/components/Marketplace/MarketplaceExtensionActions.vue
+++ b/layers/marketplace/components/Marketplace/MarketplaceExtensionActions.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { hash } from "ohash";
 import type { MarketplaceExtension } from '~/types/marketplace';
 import { formatFilesize } from '~/utils/formatFilesize';
 
@@ -10,8 +11,14 @@ const directusInstanceUrl = useCookie('directus-instance-url', {
 	default: () => '',
 });
 
+const { $posthog } = useNuxtApp();
+
 const showInstallModal = ref(false);
 const inputUrl = ref(directusInstanceUrl.value || '');
+
+function hashedUrl(url: string) {
+	return hash(new URL(url).origin);
+}
 
 const installExtension = () => {
 	if (!inputUrl.value) {
@@ -21,6 +28,24 @@ const installExtension = () => {
 	directusInstanceUrl.value = inputUrl.value;
 
 	const installUrl = `${inputUrl.value}/admin/settings/marketplace/extension/${props.extension.id}`;
+
+	const hashed_instance_url = hashedUrl(inputUrl.value);
+
+	$posthog?.capture('marketing.website.marketplace.extension.instance_url.saved', {
+		marketplace_extension_id: props.extension.id,
+		marketplace_extension_name: props.extension.name,
+		marketplace_extension_version: props.extension.versions?.[0]?.version || null,
+		marketplace_instance_url: hashed_instance_url,
+		$set: {
+			latest_marketplace_instance_url: hashed_instance_url,
+		},
+	});
+
+	$posthog?.capture('marketing.website.marketplace.extension.install.launch', {
+		marketplace_extension_id: props.extension.id,
+		marketplace_extension_name: props.extension.name,
+		marketplace_extension_version: props.extension.versions?.[0]?.version || null,
+	});
 
 	navigateTo(installUrl, {
 		external: true,
@@ -37,9 +62,27 @@ const handleInstallClick = () => {
 		// Show modal if no URL is set
 		showInstallModal.value = true;
 		inputUrl.value = '';
+
+		$posthog?.capture('marketing.website.marketplace.extension.instance_url.opened', {
+			extension_id: props.extension.id,
+			marketplace_extension_name: props.extension.name,
+			marketplace_extension_version: props.extension.versions?.[0]?.version || null,
+		});
 	} else {
 		// Go directly to marketplace if URL is already set
 		const installUrl = `${directusInstanceUrl.value}/admin/settings/marketplace/extension/${props.extension.id}`;
+
+		const hashed_instance_url = hashedUrl(directusInstanceUrl.value);
+
+		$posthog?.capture('marketing.website.marketplace.extension.install.launch', {
+			marketplace_extension_id: props.extension.id,
+			marketplace_extension_name: props.extension.name,
+			marketplace_extension_version: props.extension.versions?.[0]?.version || null,
+			marketplace_instance_url: hashed_instance_url,
+			$set: {
+				latest_marketplace_instance_url: hashed_instance_url,
+			},
+		});
 
 		navigateTo(installUrl, {
 			external: true,
@@ -53,6 +96,18 @@ const handleInstallClick = () => {
 const handleEditUrl = () => {
 	showInstallModal.value = true;
 	inputUrl.value = directusInstanceUrl.value;
+
+	const hashed_instance_url = hashedUrl(inputUrl.value);
+
+	$posthog?.capture('marketing.website.marketplace.extension.instance_url.edit', {
+		marketplace_extension_id: props.extension.id,
+		marketplace_extension_name: props.extension.name,
+		marketplace_extension_version: props.extension.versions?.[0]?.version || null,
+		marketplace_instance_url: hashed_instance_url,
+		$set: {
+			latest_marketplace_instance_url: hashed_instance_url,
+		},
+	});
 };
 
 const isSandboxed = computed(() => {
@@ -218,7 +273,19 @@ function formatSingleVersion(version: string): string {
 			<div v-if="extension?.name" class="row">
 				<span class="meta-item">
 					<BaseIcon name="fa6-brands:npm" size="small" />
-					<NuxtLink :href="`https://www.npmjs.com/package/${extension.name}`" target="_blank" class="link">
+					<NuxtLink
+						:href="`https://www.npmjs.com/package/${extension.name}`"
+						target="_blank"
+						class="link"
+						v-capture="{
+							event: 'marketing.website.marketplace.extension.npm.open',
+							props: {
+								extension_id: extension.id,
+								extension_name: extension.name,
+								extension_version: latestVersion?.version || null,
+							},
+						}"
+					>
 						npm
 					</NuxtLink>
 				</span>
@@ -227,14 +294,42 @@ function formatSingleVersion(version: string): string {
 			<div v-if="latestVersion?.url_repository" class="row">
 				<span class="meta-item">
 					<BaseIcon name="fa6-brands:github" size="small" />
-					<a :href="latestVersion.url_repository" target="_blank" class="link">Repository</a>
+					<a
+						:href="latestVersion.url_repository"
+						target="_blank"
+						class="link"
+						v-capture="{
+							event: 'marketing.website.marketplace.extension.github.open',
+							props: {
+								extension_id: extension.id,
+								extension_name: extension.name,
+								extension_version: latestVersion?.version || null,
+							},
+						}"
+					>
+						Repository
+					</a>
 				</span>
 			</div>
 
 			<div v-if="latestVersion?.url_bugs" class="row">
 				<span class="meta-item">
 					<BaseIcon name="bug_report" size="small" />
-					<a :href="latestVersion.url_bugs" target="_blank" class="link">Report Issue</a>
+					<a
+						:href="latestVersion.url_bugs"
+						target="_blank"
+						class="link"
+						v-capture="{
+							event: 'marketing.website.marketplace.extension.bugs.open',
+							props: {
+								extension_id: extension.id,
+								extension_name: extension.name,
+								extension_version: latestVersion?.version || null,
+							},
+						}"
+					>
+						Report Issue
+					</a>
 				</span>
 			</div>
 

--- a/layers/marketplace/components/Templates/TemplatesActions.vue
+++ b/layers/marketplace/components/Templates/TemplatesActions.vue
@@ -23,6 +23,15 @@ defineProps<{
 				size="large"
 				block
 				@click="button.click"
+				v-capture="{
+					name: 'marketing.website.marketplace.template.button.click',
+					properties: {
+						button,
+						button_label: button.label,
+						template_id: template.id,
+						template_name: template.name,
+					},
+				}"
 			/>
 		</BaseButtonGroup>
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"embla-carousel-class-names": "^8.5.2",
 		"embla-carousel-vue": "^8.5.2",
 		"isomorphic-dompurify": "^2.26.0",
+		"ohash": "^2.0.11",
 		"typesense": "^2.0.3",
 		"vue3-marquee": "^4.2.2",
 		"zod": "^4.0.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   isomorphic-dompurify:
     specifier: ^2.26.0
     version: 2.26.0
+  ohash:
+    specifier: ^2.0.11
+    version: 2.0.11
   typesense:
     specifier: ^2.0.3
     version: 2.1.0(@babel/runtime@7.28.3)
@@ -69,7 +72,7 @@ devDependencies:
     version: 4.1.0(eslint@9.22.0)(vite@7.1.3)(webpack@5.90.3)
   '@nuxtjs/sitemap':
     specifier: 7.2.9
-    version: 7.2.9(h3@1.15.1)(vite@7.1.3)(vue@3.5.13)
+    version: 7.2.9(h3@1.15.4)(vite@7.1.3)(vue@3.5.13)
   '@types/dompurify':
     specifier: ^3.2.0
     version: 3.2.0
@@ -120,7 +123,7 @@ devDependencies:
     version: 3.17.6(@types/node@22.13.10)(@vue/compiler-sfc@3.5.18)(eslint@9.22.0)(sass@1.89.2)(typescript@5.8.2)(vite@7.1.3)(vue-tsc@2.2.8)
   nuxt-og-image:
     specifier: 5.0.5
-    version: 5.0.5(@unhead/vue@2.0.14)(unstorage@1.15.0)(vite@7.1.3)(vue@3.5.13)
+    version: 5.0.5(@unhead/vue@2.0.14)(unstorage@1.16.1)(vite@7.1.3)(vue@3.5.13)
   nuxt-schema-org:
     specifier: 5.0.4
     version: 5.0.4(@unhead/vue@2.0.14)(vue@3.5.13)
@@ -2374,7 +2377,7 @@ packages:
       - webpack
     dev: true
 
-  /@nuxtjs/sitemap@7.2.9(h3@1.15.1)(vite@7.1.3)(vue@3.5.13):
+  /@nuxtjs/sitemap@7.2.9(h3@1.15.4)(vite@7.1.3)(vue@3.5.13):
     resolution: {integrity: sha512-LXabZyFsK+6l8TvrHOQWt00QW9DYFXiST59VGsH9nQiv39qFWaJ1x4HmrDX2l9egtj1uxzryamj+myRpKWJOdA==}
     engines: {node: '>=18.0.0'}
     dependencies:
@@ -2382,7 +2385,7 @@ packages:
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       chalk: 5.6.0
       defu: 6.1.4
-      h3-compression: 0.3.2(h3@1.15.1)
+      h3-compression: 0.3.2(h3@1.15.4)
       nuxt-site-config: 3.2.2(vue@3.5.13)
       ofetch: 1.4.1
       pathe: 2.0.3
@@ -3469,7 +3472,7 @@ packages:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
       '@types/eslint': 8.56.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
     dev: true
 
   /@types/eslint@8.56.6:
@@ -4479,13 +4482,13 @@ packages:
       event-target-shim: 5.0.1
     dev: true
 
-  /acorn-import-assertions@1.9.0(acorn@8.14.1):
+  /acorn-import-assertions@1.9.0(acorn@8.15.0):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
     dev: true
 
   /acorn-import-attributes@1.9.5(acorn@8.14.1):
@@ -6200,14 +6203,6 @@ packages:
       estraverse: 4.3.0
     dev: true
 
-  /eslint-scope@8.2.0:
-    resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: true
-
   /eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6944,12 +6939,12 @@ packages:
       duplexer: 0.1.2
     dev: true
 
-  /h3-compression@0.3.2(h3@1.15.1):
+  /h3-compression@0.3.2(h3@1.15.4):
     resolution: {integrity: sha512-B+yCKyDRnO0BXSfjAP4tCXJgJwmnKp3GyH5Yh66mY9KuOCrrGQSPk/gBFG2TgH7OyB/6mvqNZ1X0XNVuy0qRsw==}
     peerDependencies:
       h3: ^1.6.0
     dependencies:
-      h3: 1.15.1
+      h3: 1.15.4
     dev: true
 
   /h3@1.15.1:
@@ -8612,7 +8607,7 @@ packages:
       boolbase: 1.0.0
     dev: true
 
-  /nuxt-og-image@5.0.5(@unhead/vue@2.0.14)(unstorage@1.15.0)(vite@7.1.3)(vue@3.5.13):
+  /nuxt-og-image@5.0.5(@unhead/vue@2.0.14)(unstorage@1.16.1)(vite@7.1.3)(vue@3.5.13):
     resolution: {integrity: sha512-MS2w3k3lqrukrB/p712aiyk0FrJjUALTtIerfRBneBpirYKLsKPRQZdDUfIH461CKl4nRA4b1fHy+cyCHE2Y8A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -8648,7 +8643,7 @@ packages:
       strip-literal: 3.0.0
       ufo: 1.5.4
       unplugin: 2.3.7
-      unstorage: 1.15.0
+      unstorage: 1.16.1(db0@0.3.2)(ioredis@5.7.0)
       unwasm: 0.3.9
       yoga-wasm-web: 0.3.3
     transitivePeerDependencies:
@@ -8882,7 +8877,6 @@ packages:
 
   /ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
-    dev: true
 
   /on-change@5.0.1:
     resolution: {integrity: sha512-n7THCP7RkyReRSLkJb8kUWoNsxUIBxTkIp3JKno+sEz6o/9AJ3w3P9fzQkITEkMwyTKJjZciF3v/pVoouxZZMg==}
@@ -10725,7 +10719,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -11628,7 +11622,7 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.13.10
-      esbuild: 0.25.0
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -11678,13 +11672,13 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.22.0
-      eslint-scope: 8.2.0
-      eslint-visitor-keys: 4.2.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
       espree: 10.3.0
       esquery: 1.6.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11819,16 +11813,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.14.1
-      acorn-import-assertions: 1.9.0(acorn@8.14.1)
-      browserslist: 4.24.4
+      acorn: 8.15.0
+      acorn-import-assertions: 1.9.0(acorn@8.15.0)
+      browserslist: 4.25.3
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.16.0
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1


### PR DESCRIPTION
This pull request adds event tracking to the Marketplace, enabling more granular analytics for user interactions such as browsing, editing instance url, and installing. It also introduces hashed instance URL tracking for privacy.

**Marketplace and Templates UI event tracking:**

* Added `v-capture` analytics tracking for clicks on extension, integration, and template cards in `SearchDirectory.vue`, capturing relevant IDs and names for each entity. [[1]](diffhunk://#diff-f05238b5060b0b6f6cf00931777f585a85ca854df6b290f9247f9b5c60fcdb63R105-R111) [[2]](diffhunk://#diff-f05238b5060b0b6f6cf00931777f585a85ca854df6b290f9247f9b5c60fcdb63R126-R133) [[3]](diffhunk://#diff-f05238b5060b0b6f6cf00931777f585a85ca854df6b290f9247f9b5c60fcdb63R148-R155)
* Added `v-capture` tracking for template action button clicks in `TemplatesActions.vue`, including button details and template metadata.
* Added tracking for external link clicks (npm, GitHub repo, and bug report) in `MarketplaceExtensionActions.vue`, capturing extension metadata for each event. [[1]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dL221-R288) [[2]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dL230-R332)

**Hashed instance URL tracking and analytics:**

* Introduced hashing of instance URLs using the `ohash` library to anonymize and track instance usage in extension install flows, with related analytics events for opening/editing/saving instance URLs and launching installs. [[1]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR2) [[2]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR14-R22) [[3]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR32-R49) [[4]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR65-R86) [[5]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR99-R110)
* Integrated `$posthog` event capture for all major extension installation actions, including modal opens, edits, saves, and launches, with hashed instance URLs and extension details. [[1]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR32-R49) [[2]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR65-R86) [[3]](diffhunk://#diff-31325c395d633987b66101cb82ad568b77eda886df5c3b02c47139be74ea6d5dR99-R110)

**Dependency updates:**

* Added `ohash` to `package.json` for hashing functionality and updated related lockfile entries. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R72) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20-R22) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8885)
* Updated several dependencies and transitive dependencies in `pnpm-lock.yaml` for packages such as `@nuxtjs/sitemap`, `unstorage`, `acorn`, `eslint-scope`, and others. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL72-R75) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL123-R126) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2377-R2388) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3472-R3475) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4482-R4491) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6203-L6210) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6947-R6947) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8615-R8610) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8651-R8646) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10728-R10722) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11631-R11625) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11681-R11681) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11822-R11825)